### PR TITLE
use google-api-client V8

### DIFF
--- a/fluent-plugin-google-cloud-storage.gemspec
+++ b/fluent-plugin-google-cloud-storage.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "fluentd", '>= 0.10.53'
   gem.add_runtime_dependency "fluent-mixin-plaintextformatter", '>= 0.2.1'
   gem.add_runtime_dependency "fluent-mixin-config-placeholders", ">= 0.3.0"
-  gem.add_runtime_dependency "google-api-client", '~> 0.7'
+  gem.add_runtime_dependency "google-api-client", '0.8.6'
   gem.add_runtime_dependency "mime-types", '>= 3.0'
 end


### PR DESCRIPTION
We should to use google-api-client 0.8.x.
Because, new version of google-api-client V9 is not compatible with this fluent-plugin-google-cloud-storage.

This is install log of current fluent-plugin-google-cloud-storage.
```
# curl -L http://toolbelt.treasuredata.com/sh/install-redhat-td-agent2.sh | sh
# /opt/td-agent/embedded/bin/fluent-gem install fluent-plugin-google-cloud-storage
Fetching: multipart-post-2.0.0.gem (100%)
Successfully installed multipart-post-2.0.0
Fetching: faraday-0.9.2.gem (100%)
Successfully installed faraday-0.9.2
Fetching: jwt-1.5.2.gem (100%)
Successfully installed jwt-1.5.2
Fetching: little-plugger-1.1.4.gem (100%)
Successfully installed little-plugger-1.1.4
Fetching: logging-2.0.0.gem (100%)
Successfully installed logging-2.0.0
Fetching: memoist-0.14.0.gem (100%)
Successfully installed memoist-0.14.0
Fetching: os-0.9.6.gem (100%)
Successfully installed os-0.9.6
Fetching: signet-0.7.2.gem (100%)
Successfully installed signet-0.7.2
Fetching: googleauth-0.5.1.gem (100%)
Successfully installed googleauth-0.5.1
Fetching: httpclient-2.7.1.gem (100%)
Successfully installed httpclient-2.7.1
Fetching: hurley-0.2.gem (100%)
Successfully installed hurley-0.2
Fetching: uber-0.0.15.gem (100%)
Successfully installed uber-0.0.15
Fetching: representable-2.3.0.gem (100%)
Successfully installed representable-2.3.0
Fetching: retriable-2.1.0.gem (100%)
Successfully installed retriable-2.1.0
Fetching: google-api-client-0.9.1.gem (100%)
Successfully installed google-api-client-0.9.1
Fetching: fluent-plugin-google-cloud-storage-0.3.3.gem (100%)
Successfully installed fluent-plugin-google-cloud-storage-0.3.3
Parsing documentation for faraday-0.9.2
Installing ri documentation for faraday-0.9.2
Parsing documentation for fluent-plugin-google-cloud-storage-0.3.3
Installing ri documentation for fluent-plugin-google-cloud-storage-0.3.3
Parsing documentation for google-api-client-0.9.1
Installing ri documentation for google-api-client-0.9.1
Parsing documentation for googleauth-0.5.1
Installing ri documentation for googleauth-0.5.1
Parsing documentation for httpclient-2.7.1
Installing ri documentation for httpclient-2.7.1
Parsing documentation for hurley-0.2
Installing ri documentation for hurley-0.2
Parsing documentation for jwt-1.5.2
Installing ri documentation for jwt-1.5.2
Parsing documentation for little-plugger-1.1.4
Installing ri documentation for little-plugger-1.1.4
Parsing documentation for logging-2.0.0
Installing ri documentation for logging-2.0.0
Parsing documentation for memoist-0.14.0
Installing ri documentation for memoist-0.14.0
invalid options: -SHN
(invalid options are ignored)
Parsing documentation for multipart-post-2.0.0
Installing ri documentation for multipart-post-2.0.0
Parsing documentation for os-0.9.6
Installing ri documentation for os-0.9.6
Parsing documentation for representable-2.3.0
Installing ri documentation for representable-2.3.0
Parsing documentation for retriable-2.1.0
Installing ri documentation for retriable-2.1.0
Parsing documentation for signet-0.7.2
Installing ri documentation for signet-0.7.2
Parsing documentation for uber-0.0.15
Installing ri documentation for uber-0.0.15
Done installing documentation for faraday, fluent-plugin-google-cloud-storage, google-api-client, googleauth, httpclient, hurley, jwt, little-plugger, logging, memoist, multipart-post, os, representable, retriable, signet, uber after 98 seconds
16 gems installed

# cat /etc/td-agent/td-agent.conf
# tail
<source>
  type tail
  format /^(?<date>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) (?<status>\S+) \[(?<role>\S+)\] (?<info>.*)$/
  path /tmp/test.log
  pos_file /var/log/td-agent/test.pos
  tag tail.test
</source>

# post to GCS
<match tail.test>
    type google_cloud_storage
    service_email xxx.xxx.com
    service_pkcs12_path    project_id handy-compass-xxx
    bucket_id test_yako
    path tail.test/%Y/%m/%d/%H/${hostname}/${chunk_id}.log.gz
    output_include_time false
    output_include_tag  false
    buffer_path /var/log/td-agent/buffer/tail.test
    flush_interval 60s
    buffer_chunk_limit 128m
    time_slice_wait 300s
    compress gzip
</match>

# /etc/init.d/td-agent start
Starting td-agent: /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- google/api_client (LoadError)
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-google-cloud-storage-0.3.3/lib/fluent/plugin/out_google_cloud_storage.rb:46:in `initialize'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/plugin.rb:128:in `new'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/plugin.rb:128:in `new_impl'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/plugin.rb:57:in `new_output'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/agent.rb:127:in `add_match'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/agent.rb:60:in `block in configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/agent.rb:54:in `each'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/agent.rb:54:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/root_agent.rb:82:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/engine.rb:117:in `configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/engine.rb:91:in `run_configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/supervisor.rb:515:in `run_configure'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/supervisor.rb:146:in `block in start'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/supervisor.rb:352:in `call'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/supervisor.rb:352:in `main_process'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/supervisor.rb:325:in `block in supervise'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/supervisor.rb:324:in `fork'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/supervisor.rb:324:in `supervise'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/supervisor.rb:142:in `start'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/lib/fluent/command/fluentd.rb:171:in `<top (required)>'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.19/bin/fluentd:6:in `<top (required)>'
	from /opt/td-agent/embedded/bin/fluentd:23:in `load'
	from /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
	from /usr/sbin/td-agent:7:in `load'
	from /usr/sbin/td-agent:7:in `<main>'
                                                           [FAILED]

# /opt/td-agent/embedded/bin/fluent-gem uninstall google-api-client
# /opt/td-agent/embedded/bin/fluent-gem install google-api-client -v 0.8.6

# /etc/init.d/td-agent start
Starting td-agent:                                         [  OK  ]

```